### PR TITLE
Matching infrastructure improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ shipped with Xcode 10.1 (up to Mac OS X High Sierra) claim C++17
 compatibility but lack proper support for some required standard library
 component.
 
-Hence, please use GCC ≥ 8.2, mainstream Clang ≥ 7, or Xcode ≥ 10.2
+Hence, please use GCC ≥ 8.2, upstream Clang ≥ 7, or Xcode ≥ 10.2
 (macOS Mojave). For Ubuntu 18.04 or later and macOS Mojave, follow the
 following instructions, or adapt them to your system/distribution.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# BLACK
-
-[![Build Status](https://api.cirrus-ci.com/github/black-sat/black.svg)](https://cirrus-ci.com/github/black-sat/black)
+# BLACK [![Build Status](https://api.cirrus-ci.com/github/black-sat/black.svg)](https://cirrus-ci.com/github/black-sat/black)  ![MIT](https://img.shields.io/badge/license-MIT-brightgreen)
 
 BLACK (short for Bounded Ltl sAtisfiability ChecKer) is a tool for testing the
 satisfiability of LTL formulas based on the SAT encoding of the tableau method

--- a/src/lib/include/black/internal/formula/match.hpp
+++ b/src/lib/include/black/internal/formula/match.hpp
@@ -54,7 +54,7 @@ namespace std {
     struct tuple_size<black::internal::Formula>          \
       : std::integral_constant<int, Arity> { };          \
                                                          \
-    template<int I>                                      \
+    template<size_t I>                                   \
     struct tuple_element<I, black::internal::Formula> {  \
       using type = black::internal::formula;             \
     };

--- a/src/lib/include/black/logic/formula.hpp
+++ b/src/lib/include/black/logic/formula.hpp
@@ -196,6 +196,12 @@ namespace black::internal
 
     // Argument of the operator
     formula operand() const;
+
+    //
+    // Pattern matching function specific for unary formulas
+    //
+    template<typename ...Cases>
+    auto match(Cases&&...) const;
   };
 
   struct binary : handle_base<binary, binary_t>
@@ -226,6 +232,12 @@ namespace black::internal
 
     // Right hand side of the binary operator
     formula right() const;
+
+    //
+    // Pattern matching function specific for binary formulas
+    //
+    template<typename ...Cases>
+    auto match(Cases&&...) const;
   };
 
   //

--- a/src/lib/include/black/support/common.hpp
+++ b/src/lib/include/black/support/common.hpp
@@ -62,6 +62,10 @@ namespace black::internal {
 // Shorthand for perfect forwarding
 #define FWD(a) std::forward<decltype(a)>(a)
 
+// Shorthand for SFINAE-friendly small functions
+#define RETURNS_DECLTYPE(Expr) \
+  decltype(Expr) { return Expr; }
+
 // The REQUIRES() macro, an easier to use wrapper around std::enable_if
 
 // WARNING: this must stay on the same line.

--- a/tests/units/formula.cpp
+++ b/tests/units/formula.cpp
@@ -146,4 +146,29 @@ TEST_CASE("Handles")
     REQUIRE(match(p && q)      == "conjunction"s);
     REQUIRE(match(p || q)      == "binary"s);
   }
+
+  SECTION("Unary formula pattern matching")
+  {
+    auto match = [&](unary u) {
+      return u.match(
+        [](negation)     { return "negation"s;    },
+        [](tomorrow)     { return "tomorrow"s;    },
+        [](yesterday)    { return "yesterday"s;    },
+        [](always)       { return "always"s;    },
+        [](eventually)   { return "eventually"s;    },
+        [](past)         { return "past"s;    },
+        [](historically) { return "historically"s;    }
+      );
+    };
+
+    formula t = XF(p && GF(!q));
+
+    REQUIRE(t.is<tomorrow>());
+    REQUIRE(!t.is<negation>());
+
+    REQUIRE(match(!p)        == "negation"s);
+    REQUIRE(match(X(p))      == "tomorrow"s);
+    REQUIRE(match(F(p && q)) == "eventually"s);
+    REQUIRE(match(Y(p || q)) == "yesterday"s);
+  }
 }


### PR DESCRIPTION
The `match()` function now is available also on `unary` and `binary` objects,
with the corresponding restrictions on the possible cases of the match.

Moreover, the matching lambdas can accept additional arguments depending on
the arity of the formulas:

```
f.match(
  [](conjunction, formula left, formula right) { ... },
  ...
);
```