### PR TITLE
Boolean arguments in binary operators

### DIFF
--- a/src/lib/include/black/internal/alphabet_impl.hpp
+++ b/src/lib/include/black/internal/alphabet_impl.hpp
@@ -153,6 +153,46 @@ namespace black::internal {
 
     return {sigma, object};
   }
+
+  //
+  // Out-of-line implementation of the operators taking boolean args
+  inline auto operator &&(bool f1, formula f2) {
+    return conjunction(f2.alphabet()->boolean(f1), f2);
+  }
+  inline auto operator &&(formula f1, bool f2) {
+    return conjunction(f1, f1.alphabet()->boolean(f2));
+  }
+  inline auto operator ||(bool f1, formula f2) {
+    return disjunction(f2.alphabet()->boolean(f1), f2);
+  }
+  inline auto operator ||(formula f1, bool f2) {
+    return disjunction(f1, f1.alphabet()->boolean(f2));
+  }
+  inline auto U(formula f1, bool f2) {
+    return U(f1, f1.alphabet()->boolean(f2));
+  }
+  inline auto U(bool f1, formula f2) {
+    return U(f2.alphabet()->boolean(f1), f2);
+  }
+  inline auto R(formula f1, bool f2) {
+    return R(f1, f1.alphabet()->boolean(f2));
+  }
+  inline auto R(bool f1, formula f2) {
+    return R(f2.alphabet()->boolean(f1), f2);
+  }
+  inline auto S(formula f1, bool f2) {
+    return S(f1, f1.alphabet()->boolean(f2));
+  }
+  inline auto S(bool f1, formula f2) {
+    return S(f2.alphabet()->boolean(f1), f2);
+  }
+  inline auto T(formula f1, bool f2) {
+    return T(f1, f1.alphabet()->boolean(f2));
+  }
+  inline auto T(bool f1, formula f2) {
+    return T(f2.alphabet()->boolean(f1), f2);
+  }
+  
 } // namespace black::internal
 
 namespace black {

--- a/src/lib/include/black/internal/formula/impl.hpp
+++ b/src/lib/include/black/internal/formula/impl.hpp
@@ -270,7 +270,9 @@ namespace black::internal
   #undef declare_operator
 
   //
-  // Implementation of operators
+  // Implementation of most of the operators. 
+  // The ones taking boolean args need alphabet hence are implemented in 
+  // alphabet_impl.hpp
   //
   inline auto operator !(formula f) { return negation(f); }
 

--- a/src/lib/include/black/logic/formula.hpp
+++ b/src/lib/include/black/logic/formula.hpp
@@ -282,7 +282,11 @@ namespace black::internal
   //
   auto operator !(formula f);
   auto operator &&(formula f1, formula f2);
+  auto operator &&(formula f1, bool f2);
+  auto operator &&(bool f1, formula f2);
   auto operator ||(formula f1, formula f2);
+  auto operator ||(formula f1, bool f2);
+  auto operator ||(bool f1, formula f2);
 
   auto X(formula f);
   auto Y(formula f);
@@ -292,9 +296,20 @@ namespace black::internal
   auto H(formula f);
 
   auto U(formula f1, formula f2);
+  auto U(formula f1, bool f2);
+  auto U(bool f1, formula f2);
+  
   auto R(formula f1, formula f2);
+  auto R(formula f1, bool f2);
+  auto R(bool f1, formula f2);
+  
   auto S(formula f1, formula f2);
+  auto S(formula f1, bool f2);
+  auto S(bool f1, formula f2);
+  
   auto T(formula f1, formula f2);
+  auto T(formula f1, bool f2);
+  auto T(bool f1, formula f2);
 
   auto XF(formula f);
   auto XG(formula f);

--- a/tests/units/formula.cpp
+++ b/tests/units/formula.cpp
@@ -111,6 +111,22 @@ TEST_CASE("Handles")
     REQUIRE(notp2.operand() == fp);
   }
 
+  SECTION("Boolean args in binary operators") {
+    formula f1 = p && top;
+    formula b1 = p && true;
+    formula f2 = top && p;
+    formula b2 = true && p;
+    formula f3 = p && bottom;
+    formula b3 = p && false;
+    formula f4 = bottom && p;
+    formula b4 = false && p;
+
+    REQUIRE(f1 == b1);
+    REQUIRE(f2 == b2);
+    REQUIRE(f3 == b3);
+    REQUIRE(f4 == b4);
+  }
+
   SECTION("Type-specific handles") {
     auto neg = negation(p);
     auto next = tomorrow(p);


### PR DESCRIPTION
Binary operators can now be given directly boolean arguments, easing some use cases.