### PR TITLE
Additional matchers not corresponding to concrete formula types.

### DIFF
--- a/src/lib/include/black/internal/formula/impl.hpp
+++ b/src/lib/include/black/internal/formula/impl.hpp
@@ -257,7 +257,7 @@ namespace black::internal
   declare_operator(yesterday,    unary)
   declare_operator(always,       unary)
   declare_operator(eventually,   unary)
-  declare_operator(past,         unary)
+  declare_operator(once,         unary)
   declare_operator(historically, unary)
   declare_operator(conjunction, binary)
   declare_operator(disjunction, binary)
@@ -303,7 +303,7 @@ namespace black::internal
   inline auto Y(formula f) { return yesterday(f);    }
   inline auto F(formula f) { return eventually(f);   }
   inline auto G(formula f) { return always(f);       }
-  inline auto P(formula f) { return past(f);         }
+  inline auto P(formula f) { return once(f);         }
   inline auto H(formula f) { return historically(f); }
 
   inline auto U(formula f1, formula f2) { return until(f1,f2);     }

--- a/src/lib/include/black/internal/formula/match.hpp
+++ b/src/lib/include/black/internal/formula/match.hpp
@@ -24,6 +24,7 @@
 #ifndef BLACK_LOGIC_MATCH_HPP_
 #define BLACK_LOGIC_MATCH_HPP_
 
+#include <vector>
 #include <functional>
 
 #ifndef BLACK_LOGIC_FORMULA_HPP_
@@ -275,6 +276,45 @@ namespace std {
 
   #undef declare_common_type
   #undef declare_formula_ct
+
+}
+
+namespace black::internal
+{
+  //
+  // Matchers that do not correspond to concrete formula types
+  //
+  template<typename Formula>
+  struct associative_matcher 
+  {
+    associative_matcher(Formula c) { flatten(c); }
+
+    std::vector<formula> const&operands() const { return _operands; }
+
+  private:
+    std::vector<formula> _operands;
+
+    void flatten(Formula c) {
+      if(c.left().template is<Formula>())
+        flatten(*c.left().template to<Formula>());
+      else
+        _operands.push_back(c.left());
+
+      if(c.right().template is<Formula>())
+        flatten(*c.right().template to<Formula>());
+      else
+        _operands.push_back(c.right());
+    }
+  };
+
+  struct big_and : associative_matcher<conjunction> {
+    using associative_matcher<conjunction>::associative_matcher;
+  };
+
+  struct big_or : associative_matcher<disjunction> {
+    using associative_matcher<disjunction>::associative_matcher;
+  };
+
 }
 
 #endif // BLACK_LOGIC_MATCH_HPP_

--- a/src/lib/include/black/logic/formula.hpp
+++ b/src/lib/include/black/logic/formula.hpp
@@ -42,7 +42,7 @@ namespace black::internal {
     yesterday,
     always,
     eventually,
-    past,
+    once,
     historically,
     // binary formulas
     conjunction,
@@ -180,7 +180,7 @@ namespace black::internal
       yesterday,
       always,
       eventually,
-      past,
+      once,
       historically
     };
 
@@ -250,7 +250,7 @@ namespace black::internal
   struct yesterday;
   struct always;
   struct eventually;
-  struct past;
+  struct once;
   struct historically;
 
   // Binary operators. Same public interface as struct `binary`
@@ -331,6 +331,10 @@ namespace black::internal
   //
   struct big_and;
   struct big_or;
+  struct propositional;
+  struct temporal;
+  struct future;
+  struct past;
 }
 
 // Names exported from the `black` namespace
@@ -349,6 +353,10 @@ namespace black {
 
   using internal::big_and;
   using internal::big_or;
+  using internal::propositional;
+  using internal::temporal;
+  using internal::future;
+  using internal::past;
 }
 
 #include <black/internal/formula/impl.hpp>

--- a/src/lib/include/black/logic/formula.hpp
+++ b/src/lib/include/black/logic/formula.hpp
@@ -325,6 +325,12 @@ namespace black::internal
 
   // true if there is any true/false constant in the formula
   bool has_constants(formula f);
+
+  //
+  // Matchers that do not correspond to concrete formula types
+  //
+  struct big_and;
+  struct big_or;
 }
 
 // Names exported from the `black` namespace
@@ -340,6 +346,9 @@ namespace black {
   using internal::simplify;
   using internal::simplify_deep;
   using internal::has_constants;
+
+  using internal::big_and;
+  using internal::big_or;
 }
 
 #include <black/internal/formula/impl.hpp>

--- a/src/lib/include/black/logic/lex.hpp
+++ b/src/lib/include/black/logic/lex.hpp
@@ -96,7 +96,7 @@ namespace black::internal
       "Y", // yesterday
       "G", // always
       "F", // eventually
-      "P", // past
+      "P", // once
       "H", // historically
     };
 

--- a/src/lib/src/logic/formula.cpp
+++ b/src/lib/src/logic/formula.cpp
@@ -70,7 +70,7 @@ namespace black::internal {
       simplify_always,
       simplify_until,
       simplify_release,
-      [&](otherwise) -> formula { black_unreachable(); }
+      [&](past) -> formula { /* TODO */ black_unreachable(); }
     );
   }
 

--- a/src/lib/src/logic/lex.cpp
+++ b/src/lib/src/logic/lex.cpp
@@ -111,7 +111,7 @@ namespace black::internal
       {"Y",     token{unary::type::yesterday}},
       {"F",     token{unary::type::eventually}},
       {"G",     token{unary::type::always}},
-      {"P",     token{unary::type::past}},
+      {"P",     token{unary::type::once}},
       {"H",     token{unary::type::historically}},
       {"AND",   token{binary::type::conjunction}},
       {"OR",    token{binary::type::disjunction}},

--- a/src/lib/src/sat/backends/mathsat.cpp
+++ b/src/lib/src/sat/backends/mathsat.cpp
@@ -152,7 +152,7 @@ namespace black::sat::backends
         return msat_make_iff(env, 
           to_mathsat(i.left()), to_mathsat(i.right()));
       },
-      [](otherwise) -> msat_term {
+      [](temporal) -> msat_term {
         black_unreachable();
       }
     );

--- a/src/lib/src/sat/backends/mathsat.cpp
+++ b/src/lib/src/sat/backends/mathsat.cpp
@@ -125,22 +125,21 @@ namespace black::sat::backends
       [this](negation n) {
         return msat_make_not(env, to_mathsat(n.operand()));
       },
-      [this](conjunction c) {
+      [this](big_and c) {
         msat_term acc = msat_make_true(env);
 
-        formula next = c;
-        std::optional<conjunction> cnext{c};
-        do {
-          formula left = cnext->left();
-          next = cnext->right();
-          acc = msat_make_and(env, acc, to_mathsat(left));
-        } while((cnext = next.to<conjunction>()));
+        for(formula op : c.operands())
+          acc = msat_make_and(env, acc, to_mathsat(op));
 
-        return msat_make_and(env, acc, to_mathsat(next));
+        return acc;
       },
-      [this](disjunction d) {
-        return msat_make_or(env, 
-          to_mathsat(d.left()), to_mathsat(d.right()));
+      [this](big_or c) {
+        msat_term acc = msat_make_false(env);
+
+        for(formula op : c.operands())
+          acc = msat_make_or(env, acc, to_mathsat(op));
+
+        return acc;
       },
       [this](implication t) {
         return

--- a/src/lib/src/sat/backends/z3.cpp
+++ b/src/lib/src/sat/backends/z3.cpp
@@ -178,7 +178,7 @@ namespace black::sat::backends
       [this](iff, formula left, formula right) {
         return Z3_mk_iff(context, to_z3(left), to_z3(right));
       },
-      [](otherwise) -> Z3_ast {
+      [](temporal) -> Z3_ast {
         black_unreachable();
       }
     );

--- a/src/lib/src/sat/backends/z3.cpp
+++ b/src/lib/src/sat/backends/z3.cpp
@@ -152,25 +152,25 @@ namespace black::sat::backends
       [this](negation, formula n) {
         return Z3_mk_not(context, to_z3(n));
       },
-      [this](conjunction c) {
+      [this](big_and c) {
         std::vector<Z3_ast> args;
-
-        formula next = c;
-        std::optional<conjunction> cnext{c};
-        do {
-          formula left = cnext->left();
-          next = cnext->right();
-          args.push_back(to_z3(left));
-        } while((cnext = next.to<conjunction>()));
-        args.push_back(to_z3(next));
-
+        for(formula op : c.operands())
+          args.push_back(to_z3(op));
+        
         black_assert(args.size() <= std::numeric_limits<unsigned int>::max());
+
         return Z3_mk_and(context, 
           static_cast<unsigned int>(args.size()), args.data());
       },
-      [this](disjunction, formula left, formula right) {
-        Z3_ast args[] = { to_z3(left), to_z3(right) };
-        return Z3_mk_or(context, 2, args);
+      [this](big_or c) {
+        std::vector<Z3_ast> args;
+        for(formula op : c.operands())
+          args.push_back(to_z3(op));
+        
+        black_assert(args.size() <= std::numeric_limits<unsigned int>::max());
+
+        return Z3_mk_or(context, 
+          static_cast<unsigned int>(args.size()), args.data());
       },
       [this](implication, formula left, formula right) {
         return Z3_mk_implies(context, to_z3(left), to_z3(right));

--- a/src/lib/src/sat/cnf.cpp
+++ b/src/lib/src/sat/cnf.cpp
@@ -234,10 +234,10 @@ namespace black::internal
 
             return n;
           },
-          [](otherwise) -> formula { black_unreachable(); }
+          [](temporal) -> formula { black_unreachable(); }
         );
       },
-      [](otherwise) -> formula { black_unreachable(); }
+      [](temporal) -> formula { black_unreachable(); }
     );
   }
 

--- a/src/lib/src/solver/solver.cpp
+++ b/src/lib/src/solver/solver.cpp
@@ -260,10 +260,7 @@ namespace black::internal
             && (to_ground_xnf(left,k,update) ||
                 _alpha.var(std::pair(formula{X(r)},k)));
       },
-      // TODO: past operators
-      [&](otherwise) -> formula {
-        black_unreachable();
-      }
+      [&](past) -> formula { /* TODO */ black_unreachable(); }
     );
   }
 
@@ -278,10 +275,10 @@ namespace black::internal
         return unary::type::eventually;
       case unary::type::eventually:
         return unary::type::always;
-      case unary::type::past:
+      case unary::type::once:
         return unary::type::historically;
       case unary::type::historically:
-        return unary::type::past;
+        return unary::type::once;
     }
     black_unreachable();
   }

--- a/tests/units/formula.cpp
+++ b/tests/units/formula.cpp
@@ -158,7 +158,7 @@ TEST_CASE("Handles")
         [](yesterday)    { return "yesterday"s;    },
         [](always)       { return "always"s;    },
         [](eventually)   { return "eventually"s;    },
-        [](past)         { return "past"s;    },
+        [](once)         { return "once"s;    },
         [](historically) { return "historically"s;    }
       );
     };

--- a/tests/units/match.cpp
+++ b/tests/units/match.cpp
@@ -45,7 +45,7 @@ static_assert(check<boolean, tomorrow,     formula>);
 static_assert(check<boolean, yesterday,    formula>);
 static_assert(check<boolean, always,       formula>);
 static_assert(check<boolean, eventually,   formula>);
-static_assert(check<boolean, past,         formula>);
+static_assert(check<boolean, once,         formula>);
 static_assert(check<boolean, historically, formula>);
 static_assert(check<boolean, conjunction,  formula>);
 static_assert(check<boolean, disjunction,  formula>);
@@ -63,7 +63,7 @@ static_assert(check<atom, tomorrow,     formula>);
 static_assert(check<atom, yesterday,    formula>);
 static_assert(check<atom, always,       formula>);
 static_assert(check<atom, eventually,   formula>);
-static_assert(check<atom, past,         formula>);
+static_assert(check<atom, once,         formula>);
 static_assert(check<atom, historically, formula>);
 static_assert(check<atom, conjunction,  formula>);
 static_assert(check<atom, disjunction,  formula>);
@@ -80,7 +80,7 @@ static_assert(check<tomorrow, tomorrow,     tomorrow>);
 static_assert(check<tomorrow, yesterday,    unary>);
 static_assert(check<tomorrow, always,       unary>);
 static_assert(check<tomorrow, eventually,   unary>);
-static_assert(check<tomorrow, past,         unary>);
+static_assert(check<tomorrow, once,         unary>);
 static_assert(check<tomorrow, historically, unary>);
 static_assert(check<tomorrow, conjunction,  formula>);
 static_assert(check<tomorrow, disjunction,  formula>);
@@ -98,7 +98,7 @@ static_assert(check<yesterday, tomorrow,     unary>);
 static_assert(check<yesterday, yesterday,    yesterday>);
 static_assert(check<yesterday, always,       unary>);
 static_assert(check<yesterday, eventually,   unary>);
-static_assert(check<yesterday, past,         unary>);
+static_assert(check<yesterday, once,         unary>);
 static_assert(check<yesterday, historically, unary>);
 static_assert(check<yesterday, conjunction,  formula>);
 static_assert(check<yesterday, disjunction,  formula>);
@@ -116,7 +116,7 @@ static_assert(check<always, tomorrow,     unary>);
 static_assert(check<always, yesterday,    unary>);
 static_assert(check<always, always,       always>);
 static_assert(check<always, eventually,   unary>);
-static_assert(check<always, past,         unary>);
+static_assert(check<always, once,         unary>);
 static_assert(check<always, historically, unary>);
 static_assert(check<always, conjunction,  formula>);
 static_assert(check<always, disjunction,  formula>);
@@ -134,7 +134,7 @@ static_assert(check<eventually, tomorrow,     unary>);
 static_assert(check<eventually, yesterday,    unary>);
 static_assert(check<eventually, always,       unary>);
 static_assert(check<eventually, eventually,   eventually>);
-static_assert(check<eventually, past,         unary>);
+static_assert(check<eventually, once,         unary>);
 static_assert(check<eventually, historically, unary>);
 static_assert(check<eventually, conjunction,  formula>);
 static_assert(check<eventually, disjunction,  formula>);
@@ -145,23 +145,23 @@ static_assert(check<eventually, release,      formula>);
 static_assert(check<eventually, since,        formula>);
 static_assert(check<eventually, triggered,    formula>);
 
-static_assert(check<past, atom,         formula>);
-static_assert(check<past, boolean,      formula>);
-static_assert(check<past, negation,     unary>);
-static_assert(check<past, tomorrow,     unary>);
-static_assert(check<past, yesterday,    unary>);
-static_assert(check<past, always,       unary>);
-static_assert(check<past, eventually,   unary>);
-static_assert(check<past, past,         past>);
-static_assert(check<past, historically, unary>);
-static_assert(check<past, conjunction,  formula>);
-static_assert(check<past, disjunction,  formula>);
-static_assert(check<past, implication,  formula>);
-static_assert(check<past, iff,          formula>);
-static_assert(check<past, until,        formula>);
-static_assert(check<past, release,      formula>);
-static_assert(check<past, since,        formula>);
-static_assert(check<past, triggered,    formula>);
+static_assert(check<once, atom,         formula>);
+static_assert(check<once, boolean,      formula>);
+static_assert(check<once, negation,     unary>);
+static_assert(check<once, tomorrow,     unary>);
+static_assert(check<once, yesterday,    unary>);
+static_assert(check<once, always,       unary>);
+static_assert(check<once, eventually,   unary>);
+static_assert(check<once, once,         once>);
+static_assert(check<once, historically, unary>);
+static_assert(check<once, conjunction,  formula>);
+static_assert(check<once, disjunction,  formula>);
+static_assert(check<once, implication,  formula>);
+static_assert(check<once, iff,          formula>);
+static_assert(check<once, until,        formula>);
+static_assert(check<once, release,      formula>);
+static_assert(check<once, since,        formula>);
+static_assert(check<once, triggered,    formula>);
 
 static_assert(check<historically, atom,         formula>);
 static_assert(check<historically, boolean,      formula>);
@@ -170,7 +170,7 @@ static_assert(check<historically, tomorrow,     unary>);
 static_assert(check<historically, yesterday,    unary>);
 static_assert(check<historically, always,       unary>);
 static_assert(check<historically, eventually,   unary>);
-static_assert(check<historically, past,         unary>);
+static_assert(check<historically, once,         unary>);
 static_assert(check<historically, historically, historically>);
 static_assert(check<historically, conjunction,  formula>);
 static_assert(check<historically, disjunction,  formula>);
@@ -188,7 +188,7 @@ static_assert(check<conjunction, tomorrow,     formula>);
 static_assert(check<conjunction, yesterday,    formula>);
 static_assert(check<conjunction, always,       formula>);
 static_assert(check<conjunction, eventually,   formula>);
-static_assert(check<conjunction, past,         formula>);
+static_assert(check<conjunction, once,         formula>);
 static_assert(check<conjunction, historically, formula>);
 static_assert(check<conjunction, conjunction,  conjunction>);
 static_assert(check<conjunction, disjunction,  binary>);
@@ -206,7 +206,7 @@ static_assert(check<disjunction, tomorrow,     formula>);
 static_assert(check<disjunction, yesterday,    formula>);
 static_assert(check<disjunction, always,       formula>);
 static_assert(check<disjunction, eventually,   formula>);
-static_assert(check<disjunction, past,         formula>);
+static_assert(check<disjunction, once,         formula>);
 static_assert(check<disjunction, historically, formula>);
 static_assert(check<disjunction, conjunction,  binary>);
 static_assert(check<disjunction, disjunction,  disjunction>);
@@ -224,7 +224,7 @@ static_assert(check<implication, tomorrow,     formula>);
 static_assert(check<implication, yesterday,    formula>);
 static_assert(check<implication, always,       formula>);
 static_assert(check<implication, eventually,   formula>);
-static_assert(check<implication, past,         formula>);
+static_assert(check<implication, once,         formula>);
 static_assert(check<implication, historically, formula>);
 static_assert(check<implication, conjunction,  binary>);
 static_assert(check<implication, disjunction,  binary>);
@@ -242,7 +242,7 @@ static_assert(check<iff, tomorrow,     formula>);
 static_assert(check<iff, yesterday,    formula>);
 static_assert(check<iff, always,       formula>);
 static_assert(check<iff, eventually,   formula>);
-static_assert(check<iff, past,         formula>);
+static_assert(check<iff, once,         formula>);
 static_assert(check<iff, historically, formula>);
 static_assert(check<iff, conjunction,  binary>);
 static_assert(check<iff, disjunction,  binary>);
@@ -260,7 +260,7 @@ static_assert(check<until, tomorrow,     formula>);
 static_assert(check<until, yesterday,    formula>);
 static_assert(check<until, always,       formula>);
 static_assert(check<until, eventually,   formula>);
-static_assert(check<until, past,         formula>);
+static_assert(check<until, once,         formula>);
 static_assert(check<until, historically, formula>);
 static_assert(check<until, conjunction,  binary>);
 static_assert(check<until, disjunction,  binary>);
@@ -278,7 +278,7 @@ static_assert(check<release, tomorrow,     formula>);
 static_assert(check<release, yesterday,    formula>);
 static_assert(check<release, always,       formula>);
 static_assert(check<release, eventually,   formula>);
-static_assert(check<release, past,         formula>);
+static_assert(check<release, once,         formula>);
 static_assert(check<release, historically, formula>);
 static_assert(check<release, conjunction,  binary>);
 static_assert(check<release, disjunction,  binary>);
@@ -296,7 +296,7 @@ static_assert(check<since, tomorrow,     formula>);
 static_assert(check<since, yesterday,    formula>);
 static_assert(check<since, always,       formula>);
 static_assert(check<since, eventually,   formula>);
-static_assert(check<since, past,         formula>);
+static_assert(check<since, once,         formula>);
 static_assert(check<since, historically, formula>);
 static_assert(check<since, conjunction,  binary>);
 static_assert(check<since, disjunction,  binary>);
@@ -314,7 +314,7 @@ static_assert(check<triggered, tomorrow,     formula>);
 static_assert(check<triggered, yesterday,    formula>);
 static_assert(check<triggered, always,       formula>);
 static_assert(check<triggered, eventually,   formula>);
-static_assert(check<triggered, past,         formula>);
+static_assert(check<triggered, once,         formula>);
 static_assert(check<triggered, historically, formula>);
 static_assert(check<triggered, conjunction,  binary>);
 static_assert(check<triggered, disjunction,  binary>);
@@ -335,17 +335,113 @@ TEST_CASE("Non-formula matchers")
   atom p3 = sigma.var("p3");
   atom p4 = sigma.var("p4");
   atom p5 = sigma.var("p5");
-  formula f = (p1 && p2) && (p3 && (p4 && p5));
 
-  std::string result;
-  f.match(
-    [&](big_and a) {
-      for(auto op : a.operands()) {
-        result += to_string(op);
-      }
-    },
-    [](otherwise) { }
-  );
+  SECTION("big_and matcher") {
+    formula f = (p1 && p2) && (p3 && (p4 && p5));
 
-  REQUIRE(result == "p1p2p3p4p5");
+    std::string result;
+    f.match(
+      [&](big_and a) {
+        for(auto op : a.operands()) {
+          result += to_string(op);
+        }
+      },
+      [](otherwise) { }
+    );
+
+    REQUIRE(result == "p1p2p3p4p5");
+  }
+
+  SECTION("big_or matcher") {
+    formula f = (p1 || p2) || (p3 || (p4 || p5));
+
+    std::string result;
+    f.match(
+      [&](big_or a) {
+        for(auto op : a.operands()) {
+          result += to_string(op);
+        }
+      },
+      [](otherwise) { }
+    );
+
+    REQUIRE(result == "p1p2p3p4p5");
+  }
+  
+  SECTION("past matcher") {
+    formula f = S(p1,p2);
+    int i = f.match(
+      [](past p) {
+        return p.match(
+          [](yesterday) { return 1; },
+          [](once) { return 2; },
+          [](historically) { return 3; },
+          [](since) { return 4; },
+          [](triggered) { return 5; }
+        );
+      },
+      [](otherwise) { return 42; }
+    );
+    REQUIRE(i == 4);
+  }
+
+  SECTION("future matcher"){  
+    formula f = U(p1,p2);
+    int i = f.match(
+      [](future p) {
+        return p.match(
+          [](tomorrow) { return 1; },
+          [](eventually) { return 2; },
+          [](always) { return 3; },
+          [](until) { return 4; },
+          [](release) { return 5; }
+        );
+      },
+      [](otherwise) { return 42; }
+    );
+
+    REQUIRE(i == 4);
+  }
+  
+  SECTION("propositional matcher") {
+    formula f = implies(p1,p2);
+    int i = f.match(
+      [](propositional p) {
+        return p.match(
+          [](boolean) { return 1; },
+          [](atom) { return 2; },
+          [](negation) { return 3; },
+          [](conjunction) { return 4; },
+          [](disjunction) { return 5; },
+          [](implication) { return 6; },
+          [](iff) { return 7; }
+        );
+      },
+      [](temporal) -> int { black_unreachable(); }
+    );
+    REQUIRE(i == 6);
+  }
+
+  SECTION("temporal matcher") {
+    formula f = G(p1);
+    int i = f.match(
+      [](temporal p) {
+        return p.match(
+          [](tomorrow)     { return 1; },
+          [](always)       { return 2; },
+          [](eventually)   { return 3; },
+          [](until)        { return 4; },
+          [](release)      { return 5; },
+          [](yesterday)    { return 6; },
+          [](once)         { return 7; },
+          [](historically) { return 8; },
+          [](since)        { return 9; },
+          [](triggered)    { return 10; }
+        );
+      },
+      [](propositional) -> int { black_unreachable(); }
+    );
+    REQUIRE(i == 2);
+  }  
+
 }

--- a/tests/units/match.cpp
+++ b/tests/units/match.cpp
@@ -21,7 +21,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include <catch2/catch.hpp>
+
 #include <black/logic/formula.hpp>
+#include <black/logic/alphabet.hpp>
+#include <black/logic/parser.hpp>
 
 #include <type_traits>
 
@@ -320,3 +324,28 @@ static_assert(check<triggered, until,        binary>);
 static_assert(check<triggered, release,      binary>);
 static_assert(check<triggered, since,        binary>);
 static_assert(check<triggered, triggered,    triggered>);
+
+
+TEST_CASE("Non-formula matchers") 
+{
+  alphabet sigma;
+
+  atom p1 = sigma.var("p1");
+  atom p2 = sigma.var("p2");
+  atom p3 = sigma.var("p3");
+  atom p4 = sigma.var("p4");
+  atom p5 = sigma.var("p5");
+  formula f = (p1 && p2) && (p3 && (p4 && p5));
+
+  std::string result;
+  f.match(
+    [&](big_and a) {
+      for(auto op : a.operands()) {
+        result += to_string(op);
+      }
+    },
+    [](otherwise) { }
+  );
+
+  REQUIRE(result == "p1p2p3p4p5");
+}


### PR DESCRIPTION
The following matchers have been added to be used with the `match()` function:

1. `big_and`/`big_or`, to capture nested chains of conjunctions/disjunctions
2. `propositional`,`temporal`,`future`,`past` that classify the operators in various terms