### PR TITLE
Added support for different output formats

### DIFF
--- a/src/frontend/include/black/frontend/cli.hpp
+++ b/src/frontend/include/black/frontend/cli.hpp
@@ -96,6 +96,9 @@ namespace black::frontend
     // verbosity level
     inline verbosity verbosity = verbosity::message;
 
+    // output format
+    inline std::optional<std::string> output_format;
+
     // to print or not to print the model
     inline bool print_model = false;
   }

--- a/src/frontend/include/black/frontend/output.hpp
+++ b/src/frontend/include/black/frontend/output.hpp
@@ -27,8 +27,13 @@
 #include <black/logic/formula.hpp>
 #include <black/solver/solver.hpp>
 
+#include <functional>
+
 namespace black::frontend 
 {
+
+  std::function<void(std::string)> 
+  syntax_error_handler(std::optional<std::string> path);
 
   void output(tribool result, black::solver &solver, black::formula f);
 

--- a/src/frontend/src/cli.cpp
+++ b/src/frontend/src/cli.cpp
@@ -101,6 +101,10 @@ namespace black::frontend
     return black::sat::solver::backend_exists(name);
   }
 
+  static bool is_output_format(std::string const &format) {
+    return format == "readable" || format == "json";
+  }
+
   //
   // main command-line parsing entry-point
   //
@@ -122,6 +126,11 @@ namespace black::frontend
         % "translate LTL+Past formulas into LTL before checking satisfiability",
       option("-m", "--model").set(cli::print_model)
         % "print the model of the formula, when it exists",
+      (option("-o", "--output-format") 
+        & value(is_output_format, "format", cli::output_format))
+        % "Output format.\n"
+          "Accepted formats: readable, json\n"
+          "Default: readable",
       (option("-f", "--formula") & value("formula", cli::formula))
         % "LTL formula to solve",
       value("file", cli::filename).required(false)

--- a/src/frontend/src/main.cpp
+++ b/src/frontend/src/main.cpp
@@ -81,11 +81,7 @@ int ltl(std::optional<std::string> path, std::istream &file)
   black::alphabet sigma;
 
   std::optional<black::formula> f =
-    black::parse_formula(sigma, file, [&path](auto error) {
-      io::fatal(status_code::syntax_error, 
-                "syntax error: {}: {}\n", 
-                path ? *path : "<stdin>", error);
-    });
+    black::parse_formula(sigma, file, syntax_error_handler(path));
 
   black_assert(f.has_value());
 


### PR DESCRIPTION
A `-o`/`--output-format` option has been added to select the output format for BLACK. Supported values are `readable` and `json`.