### PR TITLE
Refactoring of the alphabet class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,16 @@ project(
 # User options
 option(ENABLE_TESTS "Enable test suite" ON)
 option(STATIC_BUILD "Perform a static build" OFF)
+option(ENABLE_CLANG_TIDY "Enable Clang Tidy invocation" OFF)
+
+set(CLANG_TIDY_PATH "clang-tidy" CACHE FILEPATH "PATH to clang-tidy executable")
+if(ENABLE_CLANG_TIDY)
+  message(STATUS "Clang Tidy enabled")
+  set(
+    CMAKE_CXX_CLANG_TIDY 
+    ${CLANG_TIDY_PATH} -header-filter=. -warnings-as-errors=* 
+    -checks=clang-analyzer-*,portability-*,bugprone-*,-bugprone-forwarding-reference-overload)
+endif()
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "")
   message(STATUS "Build configuration not defined. Defaulting to Release")

--- a/src/frontend/src/tracecheck.cpp
+++ b/src/frontend/src/tracecheck.cpp
@@ -222,7 +222,7 @@ namespace black::frontend
         return check(trace, l, t) == check(trace, r, t);
       },
       [&](eventually, formula op) {
-        return check(trace, U(op.alphabet()->top(), op), t);
+        return check(trace, U(op.sigma()->top(), op), t);
       },
       [&](always, formula op) {
         return check(trace, !F(!op), t);
@@ -231,7 +231,7 @@ namespace black::frontend
         return check(trace, !U(!l, !r), t);
       },
       [&](once, formula op) {
-        return check(trace, S(op.alphabet()->top(), op), t);
+        return check(trace, S(op.sigma()->top(), op), t);
       },
       [&](historically, formula op) {
         return check(trace, !O(!op), t);

--- a/src/frontend/src/tracecheck.cpp
+++ b/src/frontend/src/tracecheck.cpp
@@ -234,7 +234,7 @@ namespace black::frontend
         return check(trace, S(op.alphabet()->top(), op), t);
       },
       [&](historically, formula op) {
-        return check(trace, !P(!op), t);
+        return check(trace, !O(!op), t);
       },
       [&](triggered, formula l, formula r) {
         return check(trace, !S(!l, !r), t);

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -75,6 +75,7 @@ configure_file(include/black/support/config.hpp.in ${CMAKE_BINARY_DIR}/include/b
 #
 set (
    LIB_SRC
+   src/logic/alphabet.cpp
    src/logic/formula.cpp
    src/logic/lex.cpp
    src/logic/parser.cpp
@@ -120,7 +121,7 @@ set (
   include/black/internal/formula/match.hpp
   include/black/internal/formula/base.hpp
   include/black/internal/formula/impl.hpp
-  include/black/internal/alphabet_impl.hpp
+  include/black/internal/formula/alphabet.hpp
   include/black/internal/debug/random_formula.hpp
   include/black/solver/solver.hpp
   include/black/support/hash.hpp
@@ -144,8 +145,7 @@ set (
 #
 add_library (black ${LIB_SRC} ${LIB_HEADERS})
 
-target_link_libraries(black PRIVATE fmt::fmt)
-target_link_libraries(black PUBLIC tsl::hopscotch_map)
+target_link_libraries(black PRIVATE fmt::fmt tsl::hopscotch_map)
 target_include_directories(black PUBLIC  
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>

--- a/src/lib/include/black/internal/formula/alphabet.hpp
+++ b/src/lib/include/black/internal/formula/alphabet.hpp
@@ -27,109 +27,43 @@
 #include <black/support/meta.hpp>
 #include <black/logic/formula.hpp>
 
-#include <deque>
-#include <numeric> // for std::accumulate
-#include <tsl/hopscotch_map.h>
-
 namespace black::internal {
 
-  struct alphabet_impl
-  {
-    alphabet_impl(alphabet *sigma) : _sigma{sigma} {}
-
-    template<typename F, typename ...Args>
-    F *allocate_formula(Args&& ...args) {
-      return allocate(_tag<F>{}, FWD(args)...);
+  //
+  // Out-of-line definitions of methods of class `alphabet`
+  //
+  template<typename T, REQUIRES_OUT_OF_LINE(internal::is_hashable<T>)>
+  inline atom alphabet::var(T&& label) {
+    if constexpr(std::is_constructible_v<std::string,T>) {
+      return
+        atom{this, allocate_atom(std::string{FWD(label)})};
+    } else {
+      return atom{this, allocate_atom(FWD(label))};
     }
+  }
 
-    alphabet            *_sigma;
-
-    boolean_t            _top{true};
-    boolean_t            _bottom{false};
-
-    std::deque<atom_t>   _atoms;
-    std::deque<unary_t>  _unaries;
-    std::deque<binary_t> _binaries;
-
-    using unary_key = std::tuple<unary::type, formula_base*>;
-    using binary_key = std::tuple<binary::type,
-                                  formula_base*,
-                                  formula_base*>;
-
-    tsl::hopscotch_map<any_hashable, atom_t*> _atoms_map;
-    tsl::hopscotch_map<unary_key,   unary_t*> _unaries_map;
-    tsl::hopscotch_map<binary_key, binary_t*> _binaries_map;
-
-  private:
-    template<typename>
-    struct _tag {};
-
-    template<typename T, REQUIRES(is_hashable<T>)>
-    atom_t *allocate(_tag<atom_t>, T&& _label)
-    {
-      any_hashable label{FWD(_label)};
-
-      if(auto it = _atoms_map.find(label); it != _atoms_map.end())
-        return it->second;
-
-      atom_t *a = &_atoms.emplace_back(label);
-      _atoms_map.insert({label, a});
-
-      return a;
-    }
-
-    unary_t *
-    allocate(_tag<unary_t>, unary::type type, formula_base* arg)
-    {
-      if(auto it = _unaries_map.find({type, arg}); it != _unaries_map.end())
-        return it->second;
-
-      unary_t *f =
-        &_unaries.emplace_back(static_cast<formula_type>(type), arg);
-      _unaries_map.insert({{type, arg}, f});
-
-      return f;
-    }
-
-    binary_t *
-    allocate(_tag<binary_t>, binary::type type,
-             formula_base* arg1, formula_base* arg2)
-    {
-      auto it = _binaries_map.find({type, arg1, arg2});
-      if(it != _binaries_map.end())
-        return it->second;
-
-      binary_t *f =
-        &_binaries.emplace_back(static_cast<formula_type>(type), arg1, arg2);
-      _binaries_map.insert({{type, arg1, arg2}, f});
-
-      return f;
-    }
-  };
-
-  // Out-of-line implementation from the handle class in formula.hpp,
-  // to have a complete alphabet_impl type
+  // Out-of-line implementations from the handle_base class in formula.hpp,
+  // placed here to have a complete alphabet type
   template<typename H, typename F>
   template<typename FType, typename Arg>
-  std::pair<black::alphabet *, unary_t *>
+  std::pair<alphabet *, unary_t *>
   handle_base<H, F>::allocate_unary(FType type, Arg const&arg)
   {
     // The type is templated only because of circularity problems
     static_assert(std::is_same_v<FType, unary::type>);
 
     // Get the alphabet from the argument
-    black::alphabet *sigma = arg._alphabet;
+    class alphabet *sigma = arg._alphabet;
 
     // Ask the alphabet to actually allocate the formula
-    unary_t *object =
-      sigma->_impl->template allocate_formula<unary_t>(type, arg._formula);
+    unary_t *object = sigma->allocate_unary(type, arg._formula);
 
     return {sigma, object};
   }
 
   template<typename H, typename F>
   template<typename FType, typename Arg1, typename Arg2>
-  std::pair<black::alphabet *, binary_t *>
+  std::pair<alphabet *, binary_t *>
   handle_base<H, F>::allocate_binary(FType type,
                                      Arg1 const&arg1, Arg2 const&arg2)
   {
@@ -140,10 +74,10 @@ namespace black::internal {
     black_assert(arg1._alphabet == arg2._alphabet);
 
     // Get the alphabet from the first argument (same as the second, by now)
-    black::alphabet *sigma = arg1._alphabet;
+    class alphabet *sigma = arg1._alphabet;
 
     // Ask the alphabet to actually allocate the formula
-    binary_t *object = sigma->_impl->template allocate_formula<binary_t>(
+    binary_t *object = sigma->allocate_binary(
       type, arg1._formula, arg2._formula
     );
 
@@ -151,44 +85,6 @@ namespace black::internal {
   }
   
 } // namespace black::internal
-
-namespace black {
-  //
-  // Out-of-line definitions of methods of class `alphabet`
-  //
-  inline alphabet::alphabet()
-    : _impl{std::make_unique<internal::alphabet_impl>(this)} {}
-
-  inline boolean alphabet::boolean(bool value) {
-    return value ? top() : bottom();
-  }
-
-  inline boolean alphabet::top() {
-    return black::internal::boolean{this, &_impl->_top};
-  }
-
-  inline boolean alphabet::bottom() {
-    return black::internal::boolean{this, &_impl->_bottom};
-  }
-
-  template<typename T, REQUIRES_OUT_OF_LINE(internal::is_hashable<T>)>
-  inline atom alphabet::var(T&& label) {
-    using namespace internal;
-    if constexpr(std::is_constructible_v<std::string,T>) {
-      return
-        atom{this, _impl->allocate_formula<atom_t>(std::string{FWD(label)})};
-    } else {
-      return atom{this, _impl->allocate_formula<atom_t>(FWD(label))};
-    }
-  }
-
-  inline formula alphabet::from_id(formula_id id) {
-    using namespace internal;
-    return
-    formula{this, reinterpret_cast<formula_base *>(static_cast<uintptr_t>(id))};
-  }
-
-} // namespace black
 
 /*
  * Functions from formula.hpp that need the alphabet class

--- a/src/lib/include/black/internal/formula/base.hpp
+++ b/src/lib/include/black/internal/formula/base.hpp
@@ -39,12 +39,9 @@
 #include <string>
 #include <optional>
 
-namespace black {
-  class alphabet; // forward declaration, declared in alphabet.hpp
-}
-
 namespace black::internal
 {
+  class alphabet; // forward declaration, declared in alphabet.hpp
   class formula;
 
   constexpr bool is_boolean_type(formula_type type) {
@@ -146,28 +143,29 @@ namespace black::internal
   struct handle_base
   {
     friend class formula;
-    friend class black::alphabet;
+    friend class alphabet;
 
-    handle_base(black::alphabet *sigma, F *f) : _alphabet{sigma}, _formula{f}
+    handle_base(alphabet *sigma, F *f) 
+      : _alphabet{sigma}, _formula{f}
     { black_assert(_formula); }
 
     // This constructor takes a tuple instead of two arguments in order to
     // directly receive the return value of allocate_formula() below
-    handle_base(std::pair<black::alphabet *, F *> args)
+    handle_base(std::pair<alphabet *, F *> args)
       : handle_base{args.first, args.second} { }
 
     operator otherwise() const { return {}; }
 
     operator formula() const;
 
-    black::alphabet *alphabet() const;
+    alphabet *alphabet() const;
 
     formula_id unique_id() const;
 
   protected:
     using handled_formula_t = F;
 
-    static std::optional<H> cast(black::alphabet *sigma, formula_base *f) {
+    static std::optional<H> cast(class alphabet *sigma, formula_base *f) {
       if(auto ptr = formula_cast<typename H::handled_formula_t *>(f); ptr)
         return std::optional<H>{H{sigma, ptr}};
       return std::nullopt;
@@ -175,14 +173,14 @@ namespace black::internal
 
     // Implemented after alphabet class
     template<typename FType, typename Arg>
-    static std::pair<black::alphabet *, unary_t *>
+    static std::pair<class alphabet *, unary_t *>
     allocate_unary(FType type, Arg const&arg);
 
     template<typename FType, typename Arg1, typename Arg2>
-    static std::pair<black::alphabet *, binary_t *>
+    static std::pair<class alphabet *, binary_t *>
     allocate_binary(FType type, Arg1 const&arg1, Arg2 const&arg2);
 
-    black::alphabet *_alphabet;
+    class alphabet *_alphabet;
     F *_formula;
   };
 

--- a/src/lib/include/black/internal/formula/base.hpp
+++ b/src/lib/include/black/internal/formula/base.hpp
@@ -158,7 +158,7 @@ namespace black::internal
 
     operator formula() const;
 
-    alphabet *alphabet() const;
+    alphabet *sigma() const;
 
     formula_id unique_id() const;
 

--- a/src/lib/include/black/internal/formula/impl.hpp
+++ b/src/lib/include/black/internal/formula/impl.hpp
@@ -53,7 +53,7 @@ namespace black::internal
     return _formula->type;
   }
 
-  inline alphabet *formula::alphabet() const {
+  inline alphabet *formula::sigma() const {
     return _alphabet;
   }
 
@@ -115,7 +115,7 @@ namespace black::internal
   }
 
   template<typename H, typename F>
-  alphabet *handle_base<H,F>::alphabet() const {
+  alphabet *handle_base<H,F>::sigma() const {
     return _alphabet;
   }
 

--- a/src/lib/include/black/internal/formula/impl.hpp
+++ b/src/lib/include/black/internal/formula/impl.hpp
@@ -172,7 +172,7 @@ namespace black::internal
   struct operator_base : handle_base<H, F>
   {
     friend class formula;
-    friend class black::alphabet;
+    friend class alphabet;
 
     using base_t = handle_base<H, F>;
     using base_t::base_t;
@@ -282,17 +282,17 @@ namespace black::internal
   // The ones taking boolean args need alphabet hence are implemented in 
   // alphabet_impl.hpp
   //
-  inline auto operator !(formula f) { return negation(f); }
+  inline negation operator !(formula f) { return negation(f); }
 
-  inline auto operator &&(formula f1, formula f2) {
+  inline conjunction operator &&(formula f1, formula f2) {
     return conjunction(f1, f2);
   }
 
-  inline auto operator ||(formula f1, formula f2) {
+  inline disjunction operator ||(formula f1, formula f2) {
     return disjunction(f1, f2);
   }
 
-  inline auto implies(formula f1, formula f2) {
+  inline implication implies(formula f1, formula f2) {
     return implication(f1, f2);
   }
 
@@ -300,25 +300,25 @@ namespace black::internal
   // Note: these are found by ADL, and are *not* exported by the `black`
   //       namespace. This means the worringly generic names do not risk to
   //       cause name clashes with user names
-  inline auto X(formula f) { return tomorrow(f);     }
-  inline auto Y(formula f) { return yesterday(f);    }
-  inline auto Z(formula f) { return w_yesterday(f);  }
-  inline auto F(formula f) { return eventually(f);   }
-  inline auto G(formula f) { return always(f);       }
-  inline auto P(formula f) { return once(f);         }
-  inline auto H(formula f) { return historically(f); }
+  inline tomorrow     X(formula f) { return tomorrow(f);     }
+  inline yesterday    Y(formula f) { return yesterday(f);    }
+  inline w_yesterday  Z(formula f) { return w_yesterday(f);  }
+  inline eventually   F(formula f) { return eventually(f);   }
+  inline always       G(formula f) { return always(f);       }
+  inline once         O(formula f) { return once(f);         }
+  inline historically H(formula f) { return historically(f); }
 
-  inline auto U(formula f1, formula f2) { return until(f1,f2);     }
-  inline auto R(formula f1, formula f2) { return release(f1,f2);   }
-  inline auto S(formula f1, formula f2) { return since(f1,f2);     }
-  inline auto T(formula f1, formula f2) { return triggered(f1,f2); }
+  inline until     U(formula f1, formula f2) { return until(f1,f2);     }
+  inline release   R(formula f1, formula f2) { return release(f1,f2);   }
+  inline since     S(formula f1, formula f2) { return since(f1,f2);     }
+  inline triggered T(formula f1, formula f2) { return triggered(f1,f2); }
 
-  inline auto XF(formula f) { return X(F(f)); }
-  inline auto XG(formula f) { return X(G(f)); }
-  inline auto FG(formula f) { return F(G(f)); }
-  inline auto GF(formula f) { return G(F(f)); }
-  inline auto YP(formula f) { return Y(P(f)); }
-  inline auto YH(formula f) { return Y(H(f)); }
+  inline tomorrow   XF(formula f) { return X(F(f)); }
+  inline tomorrow   XG(formula f) { return X(G(f)); }
+  inline eventually FG(formula f) { return F(G(f)); }
+  inline always     GF(formula f) { return G(F(f)); }
+  inline yesterday  YO(formula f) { return Y(O(f)); }
+  inline yesterday  YH(formula f) { return Y(H(f)); }
 
 }
 

--- a/src/lib/include/black/logic/formula.hpp
+++ b/src/lib/include/black/logic/formula.hpp
@@ -59,10 +59,6 @@ namespace black::internal {
 
 #include <black/internal/formula/base.hpp>
 
-namespace black {
-  class alphabet;
-}
-
 namespace black::internal
 {
   class formula
@@ -94,7 +90,7 @@ namespace black::internal
     type formula_type() const;
 
     // Gets the alphabet that manages this formula
-    black::alphabet *alphabet() const;
+    alphabet *alphabet() const;
 
     //
     // The to() function converts a formula into a specific kind of
@@ -128,7 +124,7 @@ namespace black::internal
     formula_id unique_id() const;
 
   private:
-    black::alphabet *_alphabet; // the alphabet the formula comes from
+    class alphabet *_alphabet; // the alphabet the formula comes from
     formula_base *_formula; // concrete object representing the formula
 
     friend struct formula_base;
@@ -138,7 +134,7 @@ namespace black::internal
 
   // Public constructor, but for internal use
   public:
-    explicit formula(black::alphabet *sigma, formula_base *f)
+    explicit formula(class alphabet *sigma, formula_base *f)
       : _alphabet{sigma}, _formula{f} { black_assert(f != nullptr); }
   };
 
@@ -278,29 +274,30 @@ namespace black::internal
   // with user code, because these names are *not* exported by the `black`
   // namespace, but are found by argument-dependent lookup.
   //
-  auto operator !(formula f);
-  auto operator &&(formula f1, formula f2);
-  auto operator ||(formula f1, formula f2);
-  auto implies(formula f1, formula f2);
+  negation operator !(formula f);
+  conjunction operator &&(formula f1, formula f2);
+  disjunction operator ||(formula f1, formula f2);
+  implication implies(formula f1, formula f2);
 
-  auto X(formula f);
-  auto Y(formula f);
-  auto F(formula f);
-  auto G(formula f);
-  auto P(formula f);
-  auto H(formula f);
+  tomorrow     X(formula f);
+  yesterday    Y(formula f);
+  w_yesterday  Z(formula f);
+  eventually   F(formula f);
+  always       G(formula f);
+  once         O(formula f);
+  historically H(formula f);
 
-  auto U(formula f1, formula f2);
-  auto R(formula f1, formula f2);
-  auto S(formula f1, formula f2);
-  auto T(formula f1, formula f2);
+  until     U(formula f1, formula f2);
+  release   R(formula f1, formula f2);
+  since     S(formula f1, formula f2);
+  triggered T(formula f1, formula f2);
 
-  auto XF(formula f);
-  auto XG(formula f);
-  auto FG(formula f);
-  auto GF(formula f);
-  auto YP(formula f);
-  auto YH(formula f);
+  tomorrow   XF(formula f);
+  tomorrow   XG(formula f);
+  eventually FG(formula f);
+  always     GF(formula f);
+  yesterday  YP(formula f);
+  yesterday  YH(formula f);
 
   //
   // Utility functions
@@ -380,5 +377,6 @@ namespace black {
 }
 
 #include <black/internal/formula/impl.hpp>
+#include <black/logic/alphabet.hpp>
 
 #endif // BLACK_LOGIC_FORMULA_HPP_

--- a/src/lib/include/black/logic/formula.hpp
+++ b/src/lib/include/black/logic/formula.hpp
@@ -90,7 +90,7 @@ namespace black::internal
     type formula_type() const;
 
     // Gets the alphabet that manages this formula
-    alphabet *alphabet() const;
+    alphabet *sigma() const;
 
     //
     // The to() function converts a formula into a specific kind of

--- a/src/lib/src/include/black/solver/encoding.hpp
+++ b/src/lib/src/include/black/solver/encoding.hpp
@@ -41,7 +41,7 @@ namespace black::internal {
   //
   struct encoder 
   {
-    encoder(formula f) : frm{f}, sigma{frm.alphabet()}
+    encoder(formula f) : frm{f}, sigma{frm.sigma()}
     {
       frm = to_nnf(frm);
       add_xyz_requests(frm);

--- a/src/lib/src/logic/alphabet.cpp
+++ b/src/lib/src/logic/alphabet.cpp
@@ -1,0 +1,118 @@
+//
+// BLACK - Bounded Ltl sAtisfiability ChecKer
+//
+// (C) 2021 Nicola Gigante
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <black/logic/alphabet.hpp>
+
+#include <deque>
+#include <tsl/hopscotch_map.h>
+
+namespace black::internal {
+  
+  struct alphabet::alphabet_impl
+  {
+    alphabet_impl(alphabet *sigma) : _sigma{sigma} {}
+
+    alphabet            *_sigma;
+
+    boolean_t            _top{true};
+    boolean_t            _bottom{false};
+
+    std::deque<atom_t>   _atoms;
+    std::deque<unary_t>  _unaries;
+    std::deque<binary_t> _binaries;
+
+    using unary_key = std::tuple<unary::type, formula_base*>;
+    using binary_key = std::tuple<binary::type,
+                                  formula_base*,
+                                  formula_base*>;
+
+    tsl::hopscotch_map<any_hashable, atom_t*> _atoms_map;
+    tsl::hopscotch_map<unary_key,   unary_t*> _unaries_map;
+    tsl::hopscotch_map<binary_key, binary_t*> _binaries_map;
+  };
+
+  alphabet::alphabet()
+    : _impl{std::make_unique<alphabet_impl>(this)} {}
+
+  alphabet::~alphabet() = default;
+
+  boolean alphabet::boolean(bool value) {
+    return value ? top() : bottom();
+  }
+
+  boolean alphabet::top() {
+    return internal::boolean{this, &_impl->_top};
+  }
+
+  boolean alphabet::bottom() {
+    return internal::boolean{this, &_impl->_bottom};
+  }
+
+  formula alphabet::from_id(formula_id id) {
+    return
+    formula{this, reinterpret_cast<formula_base *>(static_cast<uintptr_t>(id))};
+  }
+
+  atom_t *alphabet::allocate_atom(any_hashable _label)
+  {
+    any_hashable label{FWD(_label)};
+
+    if(auto it = _impl->_atoms_map.find(label); it != _impl->_atoms_map.end())
+      return it->second;
+
+    atom_t *a = &_impl->_atoms.emplace_back(label);
+    _impl->_atoms_map.insert({label, a});
+
+    return a;
+  }
+
+  unary_t *alphabet::allocate_unary(unary::type type, formula_base* arg)
+  {
+    auto it = _impl->_unaries_map.find({type, arg});
+    if(it != _impl->_unaries_map.end())
+      return it->second;
+
+    unary_t *f =
+      &_impl->_unaries.emplace_back(static_cast<formula_type>(type), arg);
+    _impl->_unaries_map.insert({{type, arg}, f});
+
+    return f;
+  }
+
+  binary_t *alphabet::allocate_binary(
+    binary::type type, formula_base* arg1, formula_base* arg2
+  ) {
+    auto it = _impl->_binaries_map.find({type, arg1, arg2});
+    if(it != _impl->_binaries_map.end())
+      return it->second;
+
+    binary_t *f =
+      &_impl->_binaries.emplace_back(
+        static_cast<formula_type>(type), arg1, arg2
+      );
+    _impl->_binaries_map.insert({{type, arg1, arg2}, f});
+
+    return f;
+  }
+
+}

--- a/src/lib/src/logic/cnf.cpp
+++ b/src/lib/src/logic/cnf.cpp
@@ -38,7 +38,7 @@ namespace black::internal
   inline atom fresh(formula f) {
     if(f.is<atom>())
       return *f.to<atom>();
-    atom a = f.alphabet()->var(f);
+    atom a = f.sigma()->var(f);
     return a;
   }
 

--- a/src/lib/src/logic/formula.cpp
+++ b/src/lib/src/logic/formula.cpp
@@ -78,7 +78,7 @@ namespace black::internal {
   {
     // !true -> false, !false -> true
     if(auto b = op.to<boolean>(); b)
-      return n.alphabet()->boolean(!b->value()); 
+      return n.sigma()->boolean(!b->value()); 
     
     // !!p -> p
     if(auto nop = op.to<negation>(); nop)
@@ -88,7 +88,7 @@ namespace black::internal {
   }
 
   formula simplify_and(conjunction c, formula l, formula r) {
-    alphabet &sigma = *c.alphabet();
+    alphabet &sigma = *c.sigma();
     std::optional<boolean> bl = l.to<boolean>(), br = r.to<boolean>();
 
     if(!bl && !br)
@@ -105,7 +105,7 @@ namespace black::internal {
   }
 
   formula simplify_or(disjunction d, formula l, formula r) {
-    alphabet &sigma = *d.alphabet();
+    alphabet &sigma = *d.sigma();
     std::optional<boolean> bl = l.to<boolean>(), br = r.to<boolean>();
 
     if(!bl && !br)
@@ -121,7 +121,7 @@ namespace black::internal {
   }
 
   formula simplify_implication(implication t, formula l, formula r) {
-    alphabet &sigma = *t.alphabet();
+    alphabet &sigma = *t.sigma();
     std::optional<boolean> bl = l.to<boolean>(), br = r.to<boolean>();
 
     if(!bl && !br)
@@ -137,7 +137,7 @@ namespace black::internal {
   }
 
   formula simplify_iff(iff f, formula l, formula r) {
-    alphabet &sigma = *f.alphabet();
+    alphabet &sigma = *f.sigma();
     std::optional<boolean> bl = l.to<boolean>(), br = r.to<boolean>();
 
     if(!bl && !br)

--- a/src/lib/src/logic/lex.cpp
+++ b/src/lib/src/logic/lex.cpp
@@ -54,16 +54,8 @@ namespace black::internal
             s.get();
           return token{binary::type::disjunction};
 
-        // '->'
+        // '->' and '=>'
         case '-':
-          s.get();
-          if (s.peek() == '>') {
-            s.get();
-            return token{binary::type::implication};
-          }
-          return std::nullopt;
-
-        // '=>'
         case '=':
           s.get();
           if (s.peek() == '>') {
@@ -76,7 +68,7 @@ namespace black::internal
         case '<':
           s.get();
           if (s.peek() == '-' || s.peek() == '=')
-            ch = char(s.get());
+            s.get();
 
           if (s.peek() == '>') {
             s.get();

--- a/src/lib/src/logic/past_remover.cpp
+++ b/src/lib/src/logic/past_remover.cpp
@@ -43,7 +43,7 @@ namespace black::internal {
           return sub_past(!S(!left, !right));
         },
         [](once p, formula op) { return sub_past(S(p.alphabet()->top(), op)); },
-        [](historically, formula op) { return sub_past(!P(!op)); },
+        [](historically, formula op) { return sub_past(!O(!op)); },
         [](boolean b) { return b; },
         [](atom a) { return a; },
         [](unary u, formula op) {

--- a/src/lib/src/logic/past_remover.cpp
+++ b/src/lib/src/logic/past_remover.cpp
@@ -27,7 +27,7 @@
 
 namespace black::internal {
   formula sub_past(formula f) {
-    alphabet *alpha = f.alphabet();
+    alphabet *alpha = f.sigma();
 
     return f.match(
         [&](yesterday, formula op) {
@@ -42,7 +42,7 @@ namespace black::internal {
         [](triggered, formula left, formula right) {
           return sub_past(!S(!left, !right));
         },
-        [](once p, formula op) { return sub_past(S(p.alphabet()->top(), op)); },
+        [](once p, formula op) { return sub_past(S(p.sigma()->top(), op)); },
         [](historically, formula op) { return sub_past(!O(!op)); },
         [](boolean b) { return b; },
         [](atom a) { return a; },
@@ -80,7 +80,7 @@ namespace black::internal {
                 gen_semantics(op, sem);
               },
               [&](since s, formula left, formula right) {
-                alphabet *alpha = f.alphabet();
+                alphabet *alpha = f.sigma();
                 atom y = alpha->var(past_label{Y(a)});
                 formula sem_s = since_semantics(a, s, y);
                 formula sem_y = yesterday_semantics(y, Y(a));

--- a/src/lib/src/sat/backends/z3.cpp
+++ b/src/lib/src/sat/backends/z3.cpp
@@ -35,7 +35,7 @@ BLACK_REGISTER_SAT_BACKEND(z3)
 namespace black::sat::backends 
 {
   inline atom fresh(formula f) {
-    return f.alphabet()->var(f);
+    return f.sigma()->var(f);
   }
 
   struct z3::_z3_t {

--- a/src/lib/src/sat/dimacs/solver.cpp
+++ b/src/lib/src/sat/dimacs/solver.cpp
@@ -23,6 +23,8 @@
 
 #include <black/sat/dimacs.hpp>
 
+#include <tsl/hopscotch_map.h>
+
 namespace black::sat::dimacs::internal
 {
   struct solver::_solver_t {

--- a/src/lib/src/sat/dimacs/solver.cpp
+++ b/src/lib/src/sat/dimacs/solver.cpp
@@ -82,7 +82,7 @@ namespace black::sat::dimacs::internal
   // TODO: optimize corner cases (e.g. if assumption is already a literal)
   bool solver::is_sat_with(formula assumption) 
   { 
-    atom fresh = assumption.alphabet()->var(assumption);
+    atom fresh = assumption.sigma()->var(assumption);
 
     this->assert_formula(iff(fresh, assumption));
 

--- a/tests/units/parser.cpp
+++ b/tests/units/parser.cpp
@@ -57,7 +57,7 @@ TEST_CASE("Rountrip of parser and pretty-printer")
   atom q = sigma.var("q");
 
   std::vector<formula> tests = {
-    p, !p, X(p), F(p), G(p), P(p), H(p), XF(p), GF(p), XG(p),
+    p, !p, X(p), F(p), G(p), O(p), H(p), XF(p), GF(p), XG(p),
     p && q, p || q, U(p,q), S(p,q), R(p,q), T(p,q),
     p && (X(U(p,q)) || XF(!q)),
     p && implies(Y(S(p,q)), GF(!p)),

--- a/tests/units/past_remover.cpp
+++ b/tests/units/past_remover.cpp
@@ -83,7 +83,7 @@ TEST_CASE("Translation for basic past formulas")
                 && (!p_YS && G(iff(X(p_YS), p_S)))},
       {T(p,q),  (!p_T && G(iff(p_T, !q || (!p && p_YT))))
                 && (!p_YT && G(iff(X(p_YT), p_T)))},
-      {P(p),    (p_P && G(iff(p_P, p || (sigma.top() && p_YP))))
+      {O(p),    (p_P && G(iff(p_P, p || (sigma.top() && p_YP))))
                 && (!p_YP && G(iff(X(p_YP), p_P)))},
       {H(p),    (!p_H && G(iff(p_H, !p || (sigma.top() && p_YH))))
                 && (!p_YH && G(iff(X(p_YH), p_H)))}


### PR DESCRIPTION
This pull requests simplifies the implementation of the alphabet class and moves it to a `.cpp` file.
A small change in the API of the formula class comes as a by-product. This also closes issue #33.