### PR TITLE
Build system improvements

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -4,7 +4,8 @@ FROM ubuntu:$VERSION
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y make cmake gdb
 RUN apt-get update && \
-    apt-get install -y libz-dev libtsl-hopscotch-map-dev libfmt-dev libz3-dev 
+    apt-get install -y libz-dev nlohmann-json3-dev libtsl-hopscotch-map-dev \
+                       libfmt-dev libz3-dev 
 RUN apt-get update && apt-get install -y git wget python curl
 
 ARG GCC_VERSION=8
@@ -20,11 +21,6 @@ WORKDIR /catch2
 RUN git checkout v2.13.0
 WORKDIR /catch2/build
 RUN cmake -DBUILD_TESTING=OFF ..
-RUN make install
-
-RUN git clone https://github.com/nlohmann/json.git /json
-WORKDIR /json/build
-RUN cmake -DJSON_BuildTests=OFF -DBUILD_TESTING=OFF ..
 RUN make install
 
 ENTRYPOINT ["/usr/bin/env", "--"]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -4,8 +4,7 @@ FROM ubuntu:$VERSION
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y make cmake gdb
 RUN apt-get update && \
-    apt-get install -y libz-dev nlohmann-json3-dev libtsl-hopscotch-map-dev \
-                       libfmt-dev libz3-dev 
+    apt-get install -y libz-dev libtsl-hopscotch-map-dev libfmt-dev libz3-dev 
 RUN apt-get update && apt-get install -y git wget python curl
 
 ARG GCC_VERSION=8
@@ -21,6 +20,11 @@ WORKDIR /catch2
 RUN git checkout v2.13.0
 WORKDIR /catch2/build
 RUN cmake -DBUILD_TESTING=OFF ..
+RUN make install
+
+RUN git clone https://github.com/nlohmann/json.git /json
+WORKDIR /json/build
+RUN cmake -DJSON_BuildTests=OFF -DBUILD_TESTING=OFF ..
 RUN make install
 
 ENTRYPOINT ["/usr/bin/env", "--"]

--- a/src/frontend/src/cli.cpp
+++ b/src/frontend/src/cli.cpp
@@ -93,7 +93,8 @@ namespace black::frontend
     print_header();
     io::println("\nAvailable SAT backends:");
     for(auto backend : black::sat::solver::backends()) {
-      io::println(" - {}", backend);
+      bool star = backend == BLACK_DEFAULT_BACKEND;
+      io::println(" - {} {}", backend, star ? "*" : "");
     }
   }
 

--- a/src/frontend/src/dimacs.cpp
+++ b/src/frontend/src/dimacs.cpp
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include <black/support/config.hpp>
 #include <black/frontend/cli.hpp>
 #include <black/frontend/io.hpp>
 #include <black/frontend/support.hpp>
@@ -49,7 +50,8 @@ namespace black::frontend {
 
     black_assert(problem.has_value());
 
-    std::string backend = cli::sat_backend ? *cli::sat_backend : "z3";
+    std::string backend = 
+      cli::sat_backend ? *cli::sat_backend : BLACK_DEFAULT_BACKEND;
     std::optional<dimacs::solution> s = dimacs::solve(*problem, backend);
 
     dimacs::print(std::cout, s);

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -27,6 +27,25 @@ option(ENABLE_MATHSAT "Enable the MathSAT backend, if found" ON)
 option(ENABLE_CMSAT "Enable the CryptoMiniSAT backend, if found" ON)
 option(ENABLE_MINISAT "Enable the MiniSAT backend, if found" ON)
 
+set(
+  BLACK_DEFAULT_BACKEND "z3"
+  CACHE STRING "Default backend called when no -B option is given. Possible values: z3, mathsat, minisat, cmsat"
+)
+
+if(
+  NOT (BLACK_DEFAULT_BACKEND STREQUAL "z3") AND
+  NOT (BLACK_DEFAULT_BACKEND STREQUAL "mathsat") AND
+  NOT (BLACK_DEFAULT_BACKEND STREQUAL "minisat") AND
+  NOT (BLACK_DEFAULT_BACKEND STREQUAL "cmsat")
+)
+  message(
+    FATAL_ERROR 
+    "Unrecognized value for the BLACK_DEFAULT_BACKEND variable: "
+    "'${BLACK_DEFAULT_BACKEND}'\n"
+    "Possible values: z3, mathsat, minisat, cmsat"
+  )
+endif()
+
 if(ENABLE_Z3)
   find_package(Z3)
 
@@ -75,6 +94,46 @@ if(ENABLE_CMSAT)
   endif()
 else()
   message(STATUS "CryptoMiniSAT backend disabled.")
+endif()
+
+if(NOT Z3_FOUND AND BLACK_DEFAULT_BACKEND STREQUAL "z3")
+  message(
+    FATAL_ERROR 
+    "Z3 set as default backend but not found or disabled.\n"
+    "Please install Z3 or set BLACK_DEFAULT_BACKEND differently.")
+endif()
+
+if(NOT MathSAT_FOUND AND BLACK_DEFAULT_BACKEND STREQUAL "mathsat")
+  message(
+    FATAL_ERROR 
+    "MathSAT set as default backend but not found or disabled.\n"
+    "Please install MathSAT or set BLACK_DEFAULT_BACKEND differently.")
+endif()
+
+if(NOT MiniSAT_FOUND AND BLACK_DEFAULT_BACKEND STREQUAL "minisat")
+  message(
+    FATAL_ERROR 
+    "MiniSAT set as default backend but not found or disabled.\n"
+    "Please install MiniSAT or set BLACK_DEFAULT_BACKEND differently.")
+endif()
+
+if(NOT CryptoMiniSAT_FOUND AND BLACK_DEFAULT_BACKEND STREQUAL "cmsat")
+  message(
+    FATAL_ERROR 
+    "CryptoMiniSAT set as default backend but not found or disabled.\n"
+    "Please install CryptoMiniSAT or set BLACK_DEFAULT_BACKEND differently.")
+endif()
+
+if(
+  (NOT Z3_FOUND) AND 
+  (NOT MathSAT_FOUND) AND 
+  (NOT MiniSAT_FOUND) AND
+  (NOT CryptoMiniSAT_FOUND) 
+)
+  message(
+    FATAL_ERROR 
+    "No SAT backend found! At least one SAT backend is required for building"
+  )
 endif()
 
 # configure config header

--- a/src/lib/include/black/support/config.hpp.in
+++ b/src/lib/include/black/support/config.hpp.in
@@ -36,4 +36,6 @@ namespace black {
   inline std::string_view version = BLACK_VERSION;
 }
 
+#define BLACK_DEFAULT_BACKEND "${BLACK_DEFAULT_BACKEND}"
+
 #endif // BLACK_CONFIG_HPP_

--- a/src/lib/src/solver/solver.cpp
+++ b/src/lib/src/solver/solver.cpp
@@ -23,10 +23,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include <black/support/config.hpp>
+#include <black/support/range.hpp>
 #include <black/solver/solver.hpp>
 #include <black/solver/encoding.hpp>
 #include <black/sat/solver.hpp>
-#include <black/support/range.hpp>
 
 namespace black::internal
 {
@@ -51,7 +52,7 @@ namespace black::internal
     std::unique_ptr<sat::solver> sat;
 
     // the name of the currently chosen sat backend
-    std::string sat_backend = "z3"; // sensible default
+    std::string sat_backend = BLACK_DEFAULT_BACKEND; // sensible default
 
     // Main algorithm
     tribool solve(size_t k_max);

--- a/tests/units/solver.cpp
+++ b/tests/units/solver.cpp
@@ -23,6 +23,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <black/support/config.hpp>
 #include <black/logic/formula.hpp>
 #include <black/solver/solver.hpp>
 
@@ -34,7 +35,7 @@ TEST_CASE("Testing solver")
   black::solver slv;
 
   SECTION("Basic solver usage") {
-    REQUIRE(slv.sat_backend() == "z3");
+    REQUIRE(slv.sat_backend() == BLACK_DEFAULT_BACKEND);
     REQUIRE(slv.solve() == tribool::undef);
 
     auto p = sigma.var("p");


### PR DESCRIPTION
Now the Z3 backend is not mandatory anymore, but can be selected as any other backend. It is still the default backend, but now the default backend can be changed with the `BLACK_DEFAULT_BACKEND` cmake variable.