### PR TITLE
Adjust benchmarks script to the new formulas' directory structure

### DIFF
--- a/benchmarks/run
+++ b/benchmarks/run
@@ -5,7 +5,7 @@ if [ -z "$TIMEOUT" ]; then
   TIMEOUT=300 # five minutes
 fi
 
-# disable memory cap by default
+# enable memory cap by default
 if [ -z "$MCAP" ]; then
   MCAP=true
 fi
@@ -99,7 +99,9 @@ measure() {
   fi
 
   # re-output the command's standard error
-  cat $errorfile >&2
+  print_errors() {
+    cat $errorfile >&2
+  }
 
   # define the call-backs for the caller
   print_time() {
@@ -233,6 +235,7 @@ bench()
   setup_run $@
 
   do_run measure > /dev/null
+  print_errors
   print_time
   output
 }
@@ -244,7 +247,8 @@ bench_formula()
   formula=$1
   cpu=$2
 
-  family=$(echo "$formula" | cut -d/ -f1)
+  type=$(echo "$formula" | cut -d/ -f1)
+  family=$(echo "$formula" | cut -d/ -f2)
 
   statusmsg="Benchmarking formula: $formula"
   if [ "$PARALLEL_SEQ" -a "$indexfile" ]; then
@@ -257,7 +261,7 @@ bench_formula()
 
   report $statusmsg
 
-  output -n $formula $family
+  output -n $formula $type $family
   for mode in $modes; do
     report -n "- $mode..."
     setup_run $mode "$formula"
@@ -298,7 +302,7 @@ bench_all()
   # print header of the output table
   if [ ! -f "$output" ]; then
     {
-      output -n "formula family"
+      output -n "formula type family"
       for mode in $modes; do
         \printf " $mode $mode:result"
       done
@@ -322,10 +326,12 @@ Commands:
   list                            Lists all the detected solvers and modes
 
   run <solver/mode> <formula>     Runs \`solver\` with the given \`mode\`
-                                  (e.g. nuXmv/sbmc) over the given \`formula\`
+                                  (e.g. nuXmv/sbmc) over the given \`formula\`.
+                                  If it returns \`err\`, try the \`bench\`
+                                  command (below) to see the error details.
 
   bench <solver/mode> <formula>   Benchmarks \`solver\` with the given \`mode\`
-                                  (e.g. nuXmv/sbmc) over the given \`formula\`
+                                  (e.g. nuXmv/sbmc) over the given \`formula\`.
 
   bench_formula <formula>         Benchmarks the given \`formula\` with all
                                   solvers in all modes.
@@ -336,27 +342,27 @@ Commands:
 
   bench_all <file>                Runs the full benchmark of all formulas with
                                   all solvers in all modes, writing the output
-                                  data on the given \`file\`
+                                  data on the given \`file\`.
 
 ENVIRONMENT VARIABLES:
   Benchmark timeout (in seconds) can be set through the \`TIMEOUT\` environment
   variables. The default is 300 seconds.
 
-  Memory control through cgroups-v1 can be disabled setting the \'MCAP\'
-  environment variable to \'false\'. It is enabled by default.
+  Memory control through cgroups-v1 can be disabled setting the \`MCAP\`
+  environment variable to \`false\`. It is enabled by default.
 
 EXAMPLES:
-  \$ $0 bench black/default formulas/acacia/example/demo-v1.pltl
+  \$ $0 bench black/default future_only/acacia/example/demo-v1.pltl
   0.019
 
-  \$ $0 bench_formula formulas/acacia/example/demo-v1.pltl > demo-v1.dat
-  Benchmarking formula: formulas/acacia/example/demo-v1.pltl
+  \$ $0 bench_formula future_only/acacia/example/demo-v1.pltl > demo-v1.dat
+  Benchmarking formula: future_only/acacia/example/demo-v1.pltl
   - black/default...done
   - nuXmv/klive...done
   - nuXmv/sbmc...done
 
   \$ cat demo-v1.dat
-  formulas/acacia/example/demo-v1.pltl 0.020 0.096 0.042
+  future_only/acacia/example/demo-v1.pltl future_only acacia 0.020 SAT 0.096 SAT 0.042 SAT
 HELP
 }
 


### PR DESCRIPTION
- Make the script print both the type (past/future_only/etc..) and the family (aalta/random/etc..), and not just the family (that was worng in any case because it was taking the fist directory in the path which is now devoted to the type)
- Adjust HELP output with the new fixes
- Make the script print the errors in 'bench' mode: they were priviously "hidden" by the '2>&1' at line 197